### PR TITLE
Export servers configuration as System property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
-.iml
+target
+*.iml

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,14 @@ Include following extension declaration into the (root) pom.xml:
 </project>
 ```
 
+### Export servers config as System property
+
+It is possible that build system or other maven plugins can export or log project properties.
+To avoid presenting sensitive data in public place we can store configuration from servers in System parameters.
+
+To change behavior of this extension to store servers config in System parameters
+we add to project property `servers.exportAsSysProp` with value `true`.
+
 Example
 ---------------
 

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,8 @@ specified properties (-Dsettings.servers.&lt;server id&gt;.&lt;property&gt;=&lt;
 
 > ${settings.servers.server.&lt;server id&gt;.&lt;property&gt;} format is also supported for the backwards compatibility with 1.0.0 release.
 
+If you have space in serverId tag it will be replaced by "_" in property name.
+
 Usage
 ---------------
 

--- a/src/main/java/com/github/shyiko/sme/ServersExtension.java
+++ b/src/main/java/com/github/shyiko/sme/ServersExtension.java
@@ -122,6 +122,8 @@ public class ServersExtension extends AbstractMavenLifecycleParticipant implemen
     }
 
     private String[] getAliases(String serverId, String field) {
+        // replace space in serverId by "_"
+        serverId = serverId.replaceAll(" +", "_");
         return new String[]{
             "settings.servers." + serverId + "." + field,
             "settings.servers.server." + serverId + "." + field, // legacy syntax, left for backward compatibility


### PR DESCRIPTION
It is possible that build system or other maven plugins can export or log project properties. To avoid presenting sensitive data in public place we can store configuration from servers in System parameters.
